### PR TITLE
CD における引数に応じたリソースの切り替えを追加

### DIFF
--- a/.github/workflows/cloud-run.yaml
+++ b/.github/workflows/cloud-run.yaml
@@ -2,6 +2,15 @@ name: Cloud Run CI/CD
 
 on:
   workflow_dispatch:
+    inputs:
+      service:
+        description: 'Service to deploy'
+        required: true
+        type: choice
+        options:
+          - api
+          - processor
+          - receiver
 
 permissions:
   id-token: write
@@ -17,10 +26,10 @@ jobs:
       PROJECT_ID: cadence-251018
       REGION: asia-northeast1
       AR_REPO: cadence-repository # Artifact Registry の名前
-      IMAGE_NAME: cadence-api # Cloud Run で動かしてるコンテナ名
+      IMAGE_NAME: cadence-${{ github.event.inputs.service }}  # 引数でサービス名を受け取る
 
-      DOCKERFILE: api/Dockerfile
-      BUILD_CONTEXT: ./api
+      DOCKERFILE: ${{ github.event.inputs.service }}/Dockerfile
+      BUILD_CONTEXT: ./${{ github.event.inputs.service }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 目的

- 任意のリソースに対するデプロイを実現

## 変更内容

- Cloud Run の CI/CD において、引数によるリソース名の選択機能を追加

## 備考

- 規模がより大きくなった際はファイルを分割