### PR TITLE
Renovate bot の追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,15 +3,42 @@
   "extends": ["config:base"],
   "timezone": "Asia/Tokyo",
   "dependencyDashboard": true,
+  "platformAutomerge": false,
+  "automergeSchedule": ["0 10 * * *"],
   "packageRules": [
-    {
-      "matchManagers": ["gomod"],
-      "postUpdateOptions": ["gomodTidy"]
-    },
     {
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm minor/patch updates"
+      "addLabels": ["npm", "minor"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["npm", "major"],
+      "automerge": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "postUpdateOptions": ["gomodTidy"],
+      "addLabels": ["go"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "addLabels": ["minor"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major"],
+      "automerge": false
+    },
+    {
+      "matchManagers": ["npm", "gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "7 days",
+      "automerge": true,
+      "automergeType": "pr"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "timezone": "Asia/Tokyo",
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "postUpdateOptions": ["gomodTidy"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm minor/patch updates"
+    }
+  ]
+}


### PR DESCRIPTION
## 目的

- パッケージの更新を定期的にチェックする bot を追加

## 変更内容

- golang と npm に対して検知
- minor / patch に関しては七日後に自動的にマージを実施し、major は目視で確認

## 備考

- terraform や asdf といった他のツールに関しては検討中
